### PR TITLE
Fix is_ipv4/1

### DIFF
--- a/src/inet_cidr.erl
+++ b/src/inet_cidr.erl
@@ -50,7 +50,7 @@ to_string({StartAddr, _EndAddr, Len}) ->
 
 %% @doc return true if the value is an ipv4 address
 is_ipv4({A, B, C, D}) ->
-    (((A >= 0) and (A =< 65535)) and
+    (((A >= 0) and (A =< 255)) and
      ((B >= 0) and (B =< 255)) and
      ((C >= 0) and (C =< 255)) and
      ((D >= 0) and (D =< 255)));


### PR DESCRIPTION
This change fixes an issue with `is_ipv4/1` where the first value of the IPv4 tuple is allowed to be `=<` 65535 instead of `=<` 255.
