### PR TITLE
Add links to hex.pm package in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-20116-2017 (c) Benoît Chesneau
+2016-2017 (c) Benoît Chesneau
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Hex.pm version](https://img.shields.io/hexpm/v/covertool.svg?style=flat)](https://hex.pm/packages/erl_cidr)
+
 # inet_cidr
 
 CIDR library for Erlang.
@@ -5,6 +7,8 @@ CIDR library for Erlang.
 > Based on the Elixir library [InetCidr](https://github.com/Cobenian/inet_cidr) 
 but rewritten so it can be easily used in an Erlang application without 
 requiring Elixir.
+
+Available on [hex.pm](https://hex.pm) as [erl_cidr](https://hex.pm/packages/erl_cidr).
 
 ## Usage
 

--- a/src/inet_cidr.erl
+++ b/src/inet_cidr.erl
@@ -2,7 +2,7 @@
 %%% This file is part of nat-pmp released under the MIT license.
 %%% See the NOTICE for more information.
 %%%
-%%% Copyright (c) 20116-2017 Benoît Chesneau
+%%% Copyright (c) 2016-2017 Benoît Chesneau
 
 -module(inet_cidr).
 


### PR DESCRIPTION
Added links and a badge for Hex.pm package in the README, and also fix a little typo on the year in LICENSE.