### PR TITLE
README: fix hex badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Hex.pm version](https://img.shields.io/hexpm/v/covertool.svg?style=flat)](https://hex.pm/packages/erl_cidr)
+[![Hex.pm version](https://img.shields.io/hexpm/v/erl_cidr.svg?style=flat)](https://hex.pm/packages/erl_cidr)
 
 # inet_cidr
 


### PR DESCRIPTION
It looks like I messed up the hex badge in https://github.com/benoitc/inet_cidr/pull/5, causing it to display the version of [https://hex.pm/packages/covertool](https://hex.pm/packages/covertool) instead of erl_cidr. Sorry about that!